### PR TITLE
Add reusable RSA module with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Study Projects (Cryptography)
 
 Набор учебных реализаций криптографических алгоритмов: RSA, ElGamal, ГОСТ.
+Добавлен небольшой Python-пакет `study_crypto` с современным примером RSA.
 
 > ⚠️ **Дисклеймер:** код предназначен только для обучения и демонстрации идей. Не используйте эти реализации в продакшене.
 
@@ -9,6 +10,7 @@
 - `El Gamal.py`
 - `ГОСТ28147-89(Full).py`
 - `ГОСТ Р 34.10-94.py`
+- `study_crypto/` — переиспользуемые модули (RSA, теория чисел)
 - `rsa.kt` (Kotlin эксперимент)
 - `funcs.py` — вспомогательные функции
 
@@ -22,7 +24,8 @@ source .venv/bin/activate  # Windows: .venv\Scripts\activate
 
 pip install -r requirements.txt
 
-python "RSA(Full).py"
+# Небольшой CLI-дэмо нового модуля
+python -m study_crypto.rsa --bits 512 --message "Привет, RSA!"
 ```
 
 ## Тесты

--- a/study_crypto/__init__.py
+++ b/study_crypto/__init__.py
@@ -1,0 +1,23 @@
+"""Учебная коллекция примеров криптографических алгоритмов."""
+
+from .rsa import (
+    RSAKeyPair,
+    RSAPrivateKey,
+    RSAPublicKey,
+    decrypt,
+    decrypt_text,
+    encrypt,
+    encrypt_text,
+    generate_rsa_keypair,
+)
+
+__all__ = [
+    "RSAKeyPair",
+    "RSAPrivateKey",
+    "RSAPublicKey",
+    "decrypt",
+    "decrypt_text",
+    "encrypt",
+    "encrypt_text",
+    "generate_rsa_keypair",
+]

--- a/study_crypto/number_theory.py
+++ b/study_crypto/number_theory.py
@@ -1,0 +1,106 @@
+"""Вспомогательные функции теории чисел для криптографии."""
+
+from __future__ import annotations
+
+from secrets import randbelow, randbits
+from typing import Tuple
+
+_SMALL_PRIMES = (
+    3,
+    5,
+    7,
+    11,
+    13,
+    17,
+    19,
+    23,
+    29,
+    31,
+    37,
+    41,
+    43,
+    47,
+)
+
+
+def _decompose(n: int) -> Tuple[int, int]:
+    """Возвращает (s, d) такое, что n = 2**s * d и d нечётное."""
+    s = 0
+    d = n
+    while d % 2 == 0:
+        s += 1
+        d //= 2
+    return s, d
+
+
+def is_probable_prime(n: int, *, rounds: int = 16) -> bool:
+    """Проверяет число на простоту тестом Миллера–Рабина.
+
+    Для целей учебного проекта используем вероятностную проверку с 16 раундами,
+    что даёт астрономически малую вероятность ошибки для 512+ бит.
+    """
+
+    if n < 2:
+        return False
+    if n in (2, 3):
+        return True
+    if n % 2 == 0:
+        return False
+
+    for prime in _SMALL_PRIMES:
+        if n == prime:
+            return True
+        if n % prime == 0:
+            return False
+
+    s, d = _decompose(n - 1)
+    for _ in range(rounds):
+        a = randbelow(n - 3) + 2  # [2, n-2]
+        x = pow(a, d, n)
+        if x in (1, n - 1):
+            continue
+        for _ in range(s - 1):
+            x = pow(x, 2, n)
+            if x == n - 1:
+                break
+        else:
+            return False
+    return True
+
+
+def generate_prime(num_bits: int) -> int:
+    """Генерирует вероятно простое число заданной битовой длины."""
+
+    if num_bits < 2:
+        raise ValueError("Размер простого числа должен быть >= 2 бит")
+
+    while True:
+        candidate = randbits(num_bits)
+        # гарантируем нужную битовую длину и нечётность
+        candidate |= 1
+        candidate |= 1 << (num_bits - 1)
+        if is_probable_prime(candidate):
+            return candidate
+
+
+def egcd(a: int, b: int) -> Tuple[int, int, int]:
+    """Расширенный алгоритм Евклида: gcd, x, y такие, что ax + by = gcd."""
+
+    if b == 0:
+        return a, 1, 0
+    gcd, x1, y1 = egcd(b, a % b)
+    x = y1
+    y = x1 - (a // b) * y1
+    return gcd, x, y
+
+
+def mod_inverse(value: int, modulo: int) -> int:
+    """Обратный элемент по модулю."""
+
+    gcd, x, _ = egcd(value, modulo)
+    if gcd != 1:
+        raise ValueError("Обратного элемента не существует")
+    return x % modulo
+
+
+__all__ = ["generate_prime", "is_probable_prime", "mod_inverse"]

--- a/study_crypto/rsa.py
+++ b/study_crypto/rsa.py
@@ -1,0 +1,137 @@
+"""Учебная реализация RSA с акцентом на чистоту кода."""
+
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+
+from .number_theory import generate_prime, mod_inverse
+
+
+@dataclass(frozen=True)
+class RSAPublicKey:
+    """Публичный ключ RSA."""
+
+    modulus: int
+    exponent: int
+
+
+@dataclass(frozen=True)
+class RSAPrivateKey:
+    """Закрытый ключ RSA."""
+
+    modulus: int
+    exponent: int
+
+
+@dataclass(frozen=True)
+class RSAKeyPair:
+    """Пара ключей RSA."""
+
+    public: RSAPublicKey
+    private: RSAPrivateKey
+
+
+def generate_rsa_keypair(bit_size: int = 2048, *, public_exponent: int = 65537) -> RSAKeyPair:
+    """Генерирует пару RSA-ключей заданной длины."""
+
+    if bit_size < 16:
+        raise ValueError("Размер ключа должен быть не меньше 16 бит")
+
+    half = bit_size // 2
+    while True:
+        p = generate_prime(half)
+        q = generate_prime(bit_size - half)
+        if p == q:
+            continue
+        phi = (p - 1) * (q - 1)
+        if math.gcd(public_exponent, phi) == 1:
+            break
+
+    n = p * q
+    d = mod_inverse(public_exponent, phi)
+    return RSAKeyPair(
+        public=RSAPublicKey(modulus=n, exponent=public_exponent),
+        private=RSAPrivateKey(modulus=n, exponent=d),
+    )
+
+
+def _int_to_bytes(value: int) -> bytes:
+    if value == 0:
+        return b"\x00"
+    length = (value.bit_length() + 7) // 8
+    return value.to_bytes(length, "big")
+
+
+def _bytes_to_int(data: bytes) -> int:
+    return int.from_bytes(data, "big")
+
+
+def encrypt(message: bytes, key: RSAPublicKey) -> bytes:
+    """Шифрует сообщение (сырые байты)."""
+
+    message_int = _bytes_to_int(message)
+    if message_int >= key.modulus:
+        raise ValueError("Размер сообщения превышает модуль ключа")
+    cipher_int = pow(message_int, key.exponent, key.modulus)
+    return _int_to_bytes(cipher_int)
+
+
+def decrypt(ciphertext: bytes, key: RSAPrivateKey) -> bytes:
+    """Дешифрует сообщение, полученное с помощью :func:`encrypt`."""
+
+    cipher_int = _bytes_to_int(ciphertext)
+    message_int = pow(cipher_int, key.exponent, key.modulus)
+    return _int_to_bytes(message_int)
+
+
+def encrypt_text(message: str, key: RSAPublicKey, *, encoding: str = "utf-8") -> bytes:
+    """Удобная обёртка для текстовых сообщений."""
+
+    return encrypt(message.encode(encoding), key)
+
+
+def decrypt_text(ciphertext: bytes, key: RSAPrivateKey, *, encoding: str = "utf-8") -> str:
+    """Декодирует байтовое представление в строку."""
+
+    return decrypt(ciphertext, key).decode(encoding)
+
+
+def demo(bits: int, message: str | None) -> None:
+    key_pair = generate_rsa_keypair(bits)
+    print(f"Сгенерирован ключ длиной {bits} бит\n")
+    print("Публичный ключ:")
+    print(f"  n = {key_pair.public.modulus}")
+    print(f"  e = {key_pair.public.exponent}\n")
+    print("Приватный ключ:")
+    print(f"  n = {key_pair.private.modulus}")
+    print(f"  d = {key_pair.private.exponent}\n")
+
+    if message is None:
+        return
+
+    ciphertext = encrypt_text(message, key_pair.public)
+    decrypted = decrypt_text(ciphertext, key_pair.private)
+
+    print("Сообщение:", message)
+    print("Шифротекст (hex):", ciphertext.hex())
+    print("Расшифровка:", decrypted)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Учебный демо-скрипт RSA")
+    parser.add_argument(
+        "--bits", type=int, default=512, help="Размер генерируемого ключа"
+    )
+    parser.add_argument(
+        "--message",
+        type=str,
+        help="Текст для шифрования и обратного расшифрования",
+    )
+    args = parser.parse_args()
+    demo(args.bits, args.message)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Добавляем корень репозитория в PYTHONPATH, чтобы можно было импортировать пакет.
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_rsa.py
+++ b/tests/test_rsa.py
@@ -1,0 +1,34 @@
+import pytest
+
+from study_crypto import (
+    decrypt,
+    decrypt_text,
+    encrypt,
+    encrypt_text,
+    generate_rsa_keypair,
+)
+
+
+def test_encrypt_decrypt_roundtrip():
+    pair = generate_rsa_keypair(256)
+    message = b"test message"
+
+    ciphertext = encrypt(message, pair.public)
+    assert decrypt(ciphertext, pair.private) == message
+
+
+def test_encrypt_text_roundtrip():
+    pair = generate_rsa_keypair(256)
+    message = "привет"
+
+    ciphertext = encrypt_text(message, pair.public)
+    assert decrypt_text(ciphertext, pair.private) == message
+
+
+def test_message_too_long_raises():
+    pair = generate_rsa_keypair(256)
+    byte_length = (pair.public.modulus.bit_length() + 7) // 8
+    message = pair.public.modulus.to_bytes(byte_length, "big")
+
+    with pytest.raises(ValueError):
+        encrypt(message, pair.public)


### PR DESCRIPTION
## Summary
- add a reusable `study_crypto` package with RSA utilities and supporting number theory helpers
- provide a simple CLI demo for RSA key generation and round-trip encryption
- cover the new API with pytest-based smoke tests and update the README instructions

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dbb9232eec832182b80209b0c323f2